### PR TITLE
fix: handling renderqueue overrides at materialmodifier

### DIFF
--- a/Runtime/CommonComponent/MaterialModifier.cs
+++ b/Runtime/CommonComponent/MaterialModifier.cs
@@ -108,8 +108,10 @@ namespace net.rs64.TexTransTool
         {
             if (overrideMaterial == null) return (false, 0);
             if (originalMaterial == null) return (false, 0);
-            if (originalMaterial.renderQueue == overrideMaterial.renderQueue) return (false, 0);
-            return (true, overrideMaterial.renderQueue);
+            var originalRenderQueue = originalMaterial.renderQueue != -1 ? originalMaterial.renderQueue : originalMaterial.shader.renderQueue;
+            var overrideRenderQueue = overrideMaterial.renderQueue != -1 ? overrideMaterial.renderQueue : overrideMaterial.shader.renderQueue;
+            if (originalRenderQueue == overrideRenderQueue) return (false, 0);
+            return (true, overrideRenderQueue);
         }
 
         public static IEnumerable<MaterialProperty> GetProperties(Material material)


### PR DESCRIPTION
MaterialModifierにおいて、不必要にRenderQueueのオーバーライドが発生する問題を修正します。

> By default materials use [render queue](https://docs.unity3d.com/ja/2020.2/Manual/SL-SubShaderTags.html) of the shader it uses. You can override the render queue used using this variable. Note that if a shader on the material is changed, the render queue resets to that of the shader itself.

> Render queue value should be in [0..5000] range to work properly; or -1 to use the render queue from the shader.

https://docs.unity3d.com/ja/2020.2/ScriptReference/Material-renderQueue.html
より、Material.renderQueueのみを見ていた以前の実装は不適切でした。