### PR TITLE
chore: Improve NDMF Preview performance

### DIFF
--- a/Editor/NDMF/NDMFPlugin.cs
+++ b/Editor/NDMF/NDMFPlugin.cs
@@ -14,9 +14,7 @@ using net.rs64.TexTransTool.NDMF.AAO;
 namespace net.rs64.TexTransTool.NDMF
 {
 
-#if NDMF_1_8_0_OR_NEWER
     [RunsOnAllPlatforms]
-#endif
     internal class NDMFPlugin : Plugin<NDMFPlugin>
     {
         public override string QualifiedName => "net.rs64.tex-trans-tool";

--- a/Editor/NDMF/NodeExecuteDomain.cs
+++ b/Editor/NDMF/NodeExecuteDomain.cs
@@ -36,7 +36,7 @@ namespace net.rs64.TexTransTool.NDMF
         public bool UsedTextureStack { get; private set; } = false;
         public bool UsedMaterialReplace { get; private set; } = false;
         public bool UsedSetMesh { get; private set; } = false;
-        public bool UsedLookAt { get; private set; } = false;
+        public RenderAspects Reads { get; private set; } = 0;
 
 
         public NodeExecuteDomain(Dictionary<Renderer, Renderer> o2pDict, ComputeContext computeContext, IObjectRegistry objectRegistry)
@@ -55,7 +55,6 @@ namespace net.rs64.TexTransTool.NDMF
         {
             if (obj is Renderer renderer && _proxy2OriginRendererDict.ContainsKey(renderer)) { return; }
             _ctx?.Observe(obj);
-            UsedLookAt = true;
         }
         public TOut ObserveToGet<TObj, TOut>(TObj obj, Func<TObj, TOut> getAction, Func<TOut, TOut, bool>? comp = null)
                 where TObj : UnityEngine.Object
@@ -85,6 +84,36 @@ namespace net.rs64.TexTransTool.NDMF
             UsedTextureStack = true;
         }
         public IEnumerable<Renderer> EnumerateRenderers() { return _proxyDomainRenderers; }
+        public Material?[] GetMaterials(Renderer renderer)
+        {
+            Reads |= RenderAspects.Material | RenderAspects.Texture;
+            return this.GetMaterialsDefault(renderer);
+        }
+        public Decal.MeshData GetMeshData(Renderer renderer)
+        {
+            Reads |= RenderAspects.Mesh | RenderAspects.Shapes;
+            return this.GetMeshDataDefault(renderer);
+        }
+        public Mesh? GetMesh(Renderer renderer)
+        {
+            Reads |= RenderAspects.Mesh | RenderAspects.Shapes;
+            return this.GetMeshDefault(renderer);
+        }
+        public HashSet<Material> GetAllMaterials()
+        {
+            Reads |= RenderAspects.Material | RenderAspects.Texture;
+            return this.GetAllMaterialsDefault();
+        }
+        public HashSet<Texture> GetAllTextures()
+        {
+            Reads |= RenderAspects.Material | RenderAspects.Texture;
+            return this.GetAllTexturesDefault();
+        }
+        public HashSet<Texture> GetMaterialTextures(Material mat)
+        {
+            Reads |= RenderAspects.Material | RenderAspects.Texture;
+            return this.GetMaterialTexturesDefault(mat);
+        }
 
         private void RegisterRecall(Renderer proxyRenderer, Action<Renderer> recall)
         {
@@ -163,11 +192,12 @@ namespace net.rs64.TexTransTool.NDMF
         }
         public bool IsEnable(Component component)
         {
+            Reads |= RenderAspects.Shapes;
             return component switch
             {
                 Behaviour bh => _ctx.Observe(bh, b => b.enabled),
                 Renderer bh => _ctx.Observe(bh, b => b.enabled),
-                _ => true,
+                _ => this.IsEnableDefault(component),
             };
         }
 

--- a/Editor/NDMF/PreviewUtility/PreviewIslandSelector.cs
+++ b/Editor/NDMF/PreviewUtility/PreviewIslandSelector.cs
@@ -104,7 +104,7 @@ namespace net.rs64.TexTransTool.NDMF
                 _nodeDomain = nodeDomain;
             }
 
-            public RenderAspects Reads => _nodeDomain.UsedLookAt ? RenderAspects.Everything : 0;
+            public RenderAspects Reads => _nodeDomain.Reads;
             public RenderAspects WhatChanged
             {
                 get

--- a/Editor/NDMF/TexTransDomainFilter.cs
+++ b/Editor/NDMF/TexTransDomainFilter.cs
@@ -127,7 +127,9 @@ namespace net.rs64.TexTransTool.NDMF
                 Profiler.EndSample();
 
                 Profiler.BeginSample("add to all groups");
-                groups.AddRange(renderersGroup2behavior.Select(i => RenderGroup.For(i.Key).WithData(new PassingData(i.Value.OrderBy(behaviorIndex.GetValueOrDefault).ToImmutableArray()))));
+                groups.AddRange(renderersGroup2behavior
+                    .Select(i => RenderGroup.For(i.Key).WithData(new PassingData(i.Value.OrderBy(behaviorIndex.GetValueOrDefault).ToImmutableArray())))
+                    .OrderBy(g => g.Renderers[0].GetInstanceID()));
                 Profiler.EndSample();
                 Profiler.EndSample();
 
@@ -177,11 +179,11 @@ namespace net.rs64.TexTransTool.NDMF
         {
             var renderer2Behavior = new Dictionary<Renderer, HashSet<TexTransBehavior>>();
 
-            foreach (var targetKV in targetRendererGroup)
+            foreach (var targetKV in targetRendererGroup.OrderBy(i => i.Key.GetInstanceID()))
             {
                 var thisTTGroup = new HashSet<TexTransBehavior>() { { targetKV.Key } };
                 var thisGroupTarget = new HashSet<Renderer>();
-                foreach (var target in targetKV.Value)
+                foreach (var target in targetKV.Value.OrderBy(i => i.GetInstanceID()))
                 {
                     if (renderer2Behavior.ContainsKey(target))
                     {
@@ -196,7 +198,7 @@ namespace net.rs64.TexTransTool.NDMF
             }
 
             var grouping = new Dictionary<IEnumerable<Renderer>, HashSet<TexTransBehavior>>();
-            foreach (var group in renderer2Behavior.Values.Distinct()) { grouping.Add(renderer2Behavior.Where(i => i.Value == group).Select(i => i.Key), group); }
+            foreach (var group in renderer2Behavior.OrderBy(i => i.Key.GetInstanceID()).Select(i => i.Value).Distinct()) { grouping.Add(renderer2Behavior.Where(i => i.Value == group).Select(i => i.Key), group); }
             return grouping;
         }
 

--- a/Editor/NDMF/TexTransDomainFilter.cs
+++ b/Editor/NDMF/TexTransDomainFilter.cs
@@ -19,11 +19,17 @@ namespace net.rs64.TexTransTool.NDMF
     {
         public readonly TexTransPhase PreviewTargetPhase;
         public readonly int PhaseIndex;
+        private readonly PropCache<GameObject, ImmutableList<RenderGroup>> _groupsByRootCache;
 
         public TexTransDomainFilter(TexTransPhase previewTargetPhase)
         {
             PreviewTargetPhase = previewTargetPhase;
             PhaseIndex = Array.IndexOf(TexTransPhaseUtility.TexTransPhases, PreviewTargetPhase);
+            _groupsByRootCache = new(
+                nameof(TexTransDomainFilter) + "/" + nameof(BuildGroupsForRoot),
+                BuildGroupsForRoot,
+                static (left, right) => left.SequenceEqual(right)
+            );
         }
         public ImmutableList<RenderGroup> GetTargetGroups(ComputeContext context)
         {
@@ -43,12 +49,23 @@ namespace net.rs64.TexTransTool.NDMF
             var avatarRoots = ctx.GetAvatarRoots();
             Profiler.EndSample();
             var allGroups = new List<RenderGroup>();
-            var waker = new NDMFGameObjectObservedWaker(ctx);
 
             foreach (var root in avatarRoots)
             {
+                allGroups.AddRange(_groupsByRootCache.Get(ctx, root));
+            }
+
+            Profiler.EndSample();
+            return allGroups.ToImmutableList();
+        }
+
+        private ImmutableList<RenderGroup> BuildGroupsForRoot(ComputeContext ctx, GameObject root)
+        {
+                var groups = new List<RenderGroup>();
+                var waker = new NDMFGameObjectObservedWaker(ctx);
+
                 //ルートから無効化されている場合そもそもプレビューする意味がないので完全スキップ
-                if (ctx.ActiveInHierarchy(root) is false) { continue; }
+                if (ctx.ActiveInHierarchy(root) is false) { return ImmutableList<RenderGroup>.Empty; }
 
                 Profiler.BeginSample(root.name, root);
                 Profiler.BeginSample("FindAtPhase");
@@ -110,30 +127,39 @@ namespace net.rs64.TexTransTool.NDMF
                 Profiler.EndSample();
 
                 Profiler.BeginSample("add to all groups");
-                allGroups.AddRange(renderersGroup2behavior.Select(i => RenderGroup.For(i.Key).WithData(new PassingData(i.Value, domainRenderers, behaviorIndex))));
+                groups.AddRange(renderersGroup2behavior.Select(i => RenderGroup.For(i.Key).WithData(new PassingData(i.Value.OrderBy(behaviorIndex.GetValueOrDefault).ToImmutableArray()))));
                 Profiler.EndSample();
                 Profiler.EndSample();
 
                 Profiler.EndSample();
-            }
-
-            Profiler.EndSample();
-            return allGroups.ToImmutableList();
+                return groups.ToImmutableList();
         }
         class PassingData
         {
-            public HashSet<TexTransBehavior> Behaviors;
-            public Renderer[] DomainRenderers;
-            public Dictionary<TexTransBehavior, int> BehaviorIndex;
+            public ImmutableArray<TexTransBehavior> OrderedBehaviors { get; }
 
-            public PassingData(HashSet<TexTransBehavior> value, Renderer[] domainRenderers, Dictionary<TexTransBehavior, int> behaviorIndex)
+            public PassingData(ImmutableArray<TexTransBehavior> orderedBehaviors)
             {
-                Behaviors = value;
-                DomainRenderers = domainRenderers;
-                BehaviorIndex = behaviorIndex;
+                OrderedBehaviors = orderedBehaviors;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return ReferenceEquals(this, obj) || obj is PassingData other && OrderedBehaviors.SequenceEqual(other.OrderedBehaviors);
+            }
+
+            public override int GetHashCode()
+            {
+                var hash = 0;
+                foreach (var behavior in OrderedBehaviors)
+                {
+                    hash = HashCode.Combine(hash, behavior);
+                }
+
+                return hash;
             }
         }
-        private Dictionary<TexTransBehavior, int> GetFlattenBehaviorAndIndex(List<TexTransBehavior> behaviors)
+        private Dictionary<TexTransBehavior, int> GetFlattenBehaviorAndIndex(IEnumerable<TexTransBehavior> behaviors)
         {
             var behaviorIndex = new Dictionary<TexTransBehavior, int>();
 
@@ -202,14 +228,12 @@ namespace net.rs64.TexTransTool.NDMF
             var node = new TexTransPhaseNode();
             node.TargetPhase = PreviewTargetPhase;
             node.o2pDict = o2pDict;
-            node.domainRenderers = o2pDict.Values.ToArray();
-            node.behaviorIndex = data.BehaviorIndex;
 #if TTT_DISPLAY_RUNTIME_LOG
             var timer = System.Diagnostics.Stopwatch.StartNew();
 #endif
 
             Profiler.BeginSample("node.NodeExecuteAndInit");
-            node.NodeExecuteAndInit(data.Behaviors, context);
+            node.NodeExecuteAndInit(data.OrderedBehaviors, context);
             Profiler.EndSample();
 
 #if TTT_DISPLAY_RUNTIME_LOG

--- a/Editor/NDMF/TexTransPhaseNode.cs
+++ b/Editor/NDMF/TexTransPhaseNode.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using nadena.dev.ndmf;
 using nadena.dev.ndmf.preview;
 using net.rs64.TexTransTool.Build;
@@ -13,19 +14,7 @@ namespace net.rs64.TexTransTool.NDMF
     {
         //TODO : 決め打ちじゃなくて、もっと調べて正しい状態にしてもいい気がする。
         public RenderAspects Reads => _nodeDomain.UsedLookAt ? RenderAspects.Everything : 0;
-        public RenderAspects WhatChanged
-        {
-            get
-            {
-                RenderAspects flag = 0;
-
-                if (_nodeDomain.UsedMaterialReplace) flag |= RenderAspects.Material;
-                if (_nodeDomain.UsedSetMesh) flag |= RenderAspects.Mesh | RenderAspects.Texture;
-                if (_nodeDomain.UsedTextureStack) flag |= RenderAspects.Material | RenderAspects.Texture;
-
-                return flag;
-            }
-        }
+        public RenderAspects WhatChanged { get; private set; }
 
         NodeExecuteDomain _nodeDomain;
         internal TexTransPhase TargetPhase;
@@ -51,10 +40,27 @@ namespace net.rs64.TexTransTool.NDMF
             Profiler.BeginSample("MargeStack Or DomainFinish");
             _nodeDomain.DomainFinish();
             Profiler.EndSample();
+
+            RenderAspects flag = 0;
+
+            if (_nodeDomain.UsedMaterialReplace) flag |= RenderAspects.Material;
+            if (_nodeDomain.UsedSetMesh) flag |= RenderAspects.Mesh | RenderAspects.Texture;
+            if (_nodeDomain.UsedTextureStack) flag |= RenderAspects.Material | RenderAspects.Texture;
+
+            WhatChanged = flag;
         }
         public void OnFrame(Renderer original, Renderer proxy)
         {
             _nodeDomain.DomainRecaller(original, proxy);
+        }
+        public Task<IRenderFilterNode> Refresh(IEnumerable<(Renderer, Renderer)> proxyPairs, ComputeContext context, RenderAspects updatedAspects)
+        {
+            if (updatedAspects != 0 && (updatedAspects & Reads) == 0)
+            {
+                WhatChanged = 0;
+                return Task.FromResult<IRenderFilterNode>(this);
+            }
+            return Task.FromResult<IRenderFilterNode>(null);
         }
 
         void IDisposable.Dispose()

--- a/Editor/NDMF/TexTransPhaseNode.cs
+++ b/Editor/NDMF/TexTransPhaseNode.cs
@@ -30,16 +30,14 @@ namespace net.rs64.TexTransTool.NDMF
         NodeExecuteDomain _nodeDomain;
         internal TexTransPhase TargetPhase;
         internal Dictionary<Renderer, Renderer> o2pDict;
-        internal Renderer[] domainRenderers;
-        internal Dictionary<TexTransBehavior, int> behaviorIndex;
-        public void NodeExecuteAndInit(IEnumerable<TexTransBehavior> flattenTTB, ComputeContext ctx)
+        public void NodeExecuteAndInit(IEnumerable<TexTransBehavior> orderedBehaviors, ComputeContext ctx)
         {
             Profiler.BeginSample("NodeExecuteDomain.ctr");
             _nodeDomain = new NodeExecuteDomain(o2pDict, ctx, ObjectRegistry.ActiveRegistry);
             Profiler.EndSample();
 
             Profiler.BeginSample("apply ttb s");
-            foreach (var behavior in flattenTTB.OrderBy(behaviorIndex.GetValueOrDefault))
+            foreach (var behavior in orderedBehaviors)
             {
                 if (behavior == null) { continue; }
                 ctx.Observe(behavior);

--- a/Editor/NDMF/TexTransPhaseNode.cs
+++ b/Editor/NDMF/TexTransPhaseNode.cs
@@ -12,8 +12,7 @@ namespace net.rs64.TexTransTool.NDMF
 {
     internal class TexTransPhaseNode : IRenderFilterNode
     {
-        //TODO : 決め打ちじゃなくて、もっと調べて正しい状態にしてもいい気がする。
-        public RenderAspects Reads => _nodeDomain.UsedLookAt ? RenderAspects.Everything : 0;
+        public RenderAspects Reads => _nodeDomain.Reads;
         public RenderAspects WhatChanged { get; private set; }
 
         NodeExecuteDomain _nodeDomain;

--- a/Editor/NDMF/net.rs64.tex-trans-tool.ndmf.asmdef
+++ b/Editor/NDMF/net.rs64.tex-trans-tool.ndmf.asmdef
@@ -47,13 +47,8 @@
     },
     {
       "name": "nadena.dev.ndmf",
-      "expression": "1.7.0",
+      "expression": "1.11.0",
       "define": "CONTAINS_NDMF"
-    },
-    {
-      "name": "nadena.dev.ndmf",
-      "expression": "1.8.0-alpha.0",
-      "define": "NDMF_1_8_0_OR_NEWER"
     }
   ],
   "noEngineReferences": false

--- a/Editor/NDMFNotExistWarning/net.rs64.tex-trans-tool.editor.ndmf-not-exist-waring.asmdef
+++ b/Editor/NDMFNotExistWarning/net.rs64.tex-trans-tool.editor.ndmf-not-exist-waring.asmdef
@@ -33,7 +33,7 @@
         },
         {
             "name": "nadena.dev.ndmf",
-            "expression": "1.7.0",
+            "expression": "1.11.0",
             "define": "NDMF_DEPEND_VERSION"
         }
     ],

--- a/Runtime/IDomain.cs
+++ b/Runtime/IDomain.cs
@@ -64,31 +64,23 @@ namespace net.rs64.TexTransTool
         IEnumerable<Renderer> EnumerateRenderers();
         Material?[] GetMaterials(Renderer renderer)
         {
-            return ObserveToGet(renderer, GetSharedMaterials, (l, r) => l.SequenceEqual(r));
-            Material?[] GetSharedMaterials(Renderer r) { return renderer.sharedMaterials; }
+            return this.GetMaterialsDefault(renderer);
         }
-        MeshData GetMeshData(Renderer renderer) { return renderer.GetToMemorizedMeshData(); }
-        Mesh? GetMesh(Renderer renderer) { return renderer.GetMesh(); }
+        MeshData GetMeshData(Renderer renderer) { return this.GetMeshDataDefault(renderer); }
+        Mesh? GetMesh(Renderer renderer) { return this.GetMeshDefault(renderer); }
 
         // ここで得られる Material は Renderer に存在するもの以外も入りうる
         HashSet<Material> GetAllMaterials()
         {
-            var matHash = new HashSet<Material>();
-            foreach (var r in EnumerateRenderers()) { matHash.UnionWith(GetMaterials(r).SkipDestroyed()); }
-            return matHash;
+            return this.GetAllMaterialsDefault();
         }
         HashSet<Texture> GetAllTextures()
         {
-            var texHash = new HashSet<Texture>();
-            var mats = GetAllMaterials();
-            foreach (var m in mats) { texHash.UnionWith(m.EnumerateTextures(GetShader, GetTex)); }
-            return texHash;
-            Shader GetShader(Material mat) { return ObserveToGet(mat, i => i.shader); }
-            Texture GetTex(Material mat, int nameID) { return ObserveToGet(mat, i => i.GetTexture(nameID)); }
+            return this.GetAllTexturesDefault();
         }
         HashSet<Texture> GetMaterialTextures(Material mat)
         {
-            return mat.EnumerateReferencedTextures().ToHashSet();
+            return this.GetMaterialTexturesDefault(mat);
         }
     }
     internal interface IUnityObjectObserver
@@ -114,12 +106,7 @@ namespace net.rs64.TexTransTool
         }
         bool IsEnable(Component component)
         {
-            return component switch
-            {
-                Behaviour bh => bh.enabled,
-                Renderer bh => bh.enabled,
-                _ => true,
-            };
+            return this.IsEnableDefault(component);
         }
     }
     internal interface ITextureDescriptionRegistry
@@ -224,6 +211,47 @@ namespace net.rs64.TexTransTool
     }
     internal static class DomainUtility
     {
+        public static Material?[] GetMaterialsDefault(this IDomainReferenceViewer rendererTargeting, Renderer renderer)
+        {
+            return rendererTargeting.ObserveToGet(renderer, GetSharedMaterials, (l, r) => l.SequenceEqual(r));
+            Material?[] GetSharedMaterials(Renderer r) { return renderer.sharedMaterials; }
+        }
+        public static MeshData GetMeshDataDefault(this IDomainReferenceViewer rendererTargeting, Renderer renderer)
+        {
+            return renderer.GetToMemorizedMeshData();
+        }
+        public static Mesh? GetMeshDefault(this IDomainReferenceViewer rendererTargeting, Renderer renderer)
+        {
+            return renderer.GetMesh();
+        }
+        public static HashSet<Material> GetAllMaterialsDefault(this IDomainReferenceViewer rendererTargeting)
+        {
+            var matHash = new HashSet<Material>();
+            foreach (var r in rendererTargeting.EnumerateRenderers()) { matHash.UnionWith(rendererTargeting.GetMaterials(r).SkipDestroyed()); }
+            return matHash;
+        }
+        public static HashSet<Texture> GetAllTexturesDefault(this IDomainReferenceViewer rendererTargeting)
+        {
+            var texHash = new HashSet<Texture>();
+            var mats = rendererTargeting.GetAllMaterials();
+            foreach (var m in mats) { texHash.UnionWith(m.EnumerateTextures(GetShader, GetTex)); }
+            return texHash;
+            Shader GetShader(Material mat) { return rendererTargeting.ObserveToGet(mat, i => i.shader); }
+            Texture GetTex(Material mat, int nameID) { return rendererTargeting.ObserveToGet(mat, i => i.GetTexture(nameID)); }
+        }
+        public static HashSet<Texture> GetMaterialTexturesDefault(this IDomainReferenceViewer rendererTargeting, Material mat)
+        {
+            return mat.EnumerateReferencedTextures().ToHashSet();
+        }
+        public static bool IsEnableDefault(this IActivenessViewer activenessViewer, Component component)
+        {
+            return component switch
+            {
+                Behaviour bh => bh.enabled,
+                Renderer bh => bh.enabled,
+                _ => true,
+            };
+        }
         public static UnityObjectEqualityComparison ObjectEqual = (l, r) =>
         {
             if (l == null) { return r == null; }


### PR DESCRIPTION
NDMF Peviewにおける対象決定やノードの再利用性、更新の抑制を行うことでパフォーマンスを改善します
なお、関連して要求するNDMFのバージョンが1.11.0以降に変更されています。

7f96ed567e35ca2309221ae33e6b66b6b4917044, 916ba729d2d2573427ac62f48a4cc50f8e4d1def では、root単位のRenderGroup構築へのPropCache導入や、Rendererの順序とPassingDataの等価性比較を安定化させることで、対象決定の再計算と不要な更新発火を抑制しています。
外部 filterの対象決定が発火して GetTargetGroupsが再度呼ばれる場合でも、TTT側の監視がinvalidatedされていない場合はcacheから高速に結果を返せます。
また、TTT 内部の監視がinvalidatedされた場合でも、最終的なRenderGroupのコレクションが変化しなければ、PropCacheによりプレビューシステム全体へのinvalidation 伝播を抑制できます。
さらに、NDMF 側の実装詳細として、RenderGroup の等価性が安定することで、ノードの再生成ではなくRefreshが試行されやすくなります。

1ccd2ecf039afe53b9563d8b24cf8d293771f3b7 ではRefreshの実装とWhatChangedの適切な更新により、ノード生成時の再計算と不要な更新発火を抑制しています。
Readしてない上流の変更時にノードを再利用したり、前回のノードからの変化を示すWhatChangedを再利用時に0とすることで、下流の不要な更新を抑制します。

70e706e851755152f9bc83387b3450dbf3376c0a, 1a023d8247fdcf8a0c53a43f2a46e187a0a971b8 ではTodoにもあった通りノードの内のReadが0かEverythingで極端(ノードの再利用も実質できない)ので、NodeExecuteDomain内の呼び出す関数ごとにReadsを登録するようにしました。関連して、そのためにインターフェースのデフォルト実装をそのまま写経するのは微妙だと思ってので、共通処理をutility 拡張として切り出しました。

9629f6f0f8c17fa6aa53403bf3b12817cdadb751 では今回追加したPropCacheがNDMF 1.11.0で追加されたので要求バージョンを変更しています。

理解している範囲ではコード上は問題なさそうですが、動作確認がまだなのでDraftにしています。
ただ変更範囲が思ったより広がったのもあるので、レビューしてくれると助かります。