### PR TITLE
perf: NodeExecuteDomain の最適化

### DIFF
--- a/Editor/NDMF/NodeExecuteDomain.cs
+++ b/Editor/NDMF/NodeExecuteDomain.cs
@@ -8,6 +8,7 @@ using nadena.dev.ndmf.preview;
 using net.rs64.TexTransCore;
 using net.rs64.TexTransCoreEngineForUnity;
 using net.rs64.TexTransTool.Utils;
+using Unity.Profiling;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
@@ -17,6 +18,11 @@ namespace net.rs64.TexTransTool.NDMF
 {
     internal class NodeExecuteDomain : IDomain, IDisposable
     {
+        private static readonly ProfilerMarker DomainRecallerMarker = new("NodeExecuteDomain.DomainRecaller");
+        private static readonly ProfilerMarker DomainRecallerLookupMarker = new("NodeExecuteDomain.DomainRecaller.Lookup");
+        private static readonly ProfilerMarker DomainRecallerSetMeshMarker = new("NodeExecuteDomain.DomainRecaller.SetMesh");
+        private static readonly ProfilerMarker DomainRecallerSetMaterialsMarker = new("NodeExecuteDomain.DomainRecaller.SetMaterials");
+
         HashSet<UnityEngine.Object> _transferredObject = new();
         HashSet<ITTRenderTexture> _transferredRenderTextures = new();
         // HashSet<RenderTexture> _neededReleaseTempRt = new();
@@ -29,7 +35,8 @@ namespace net.rs64.TexTransTool.NDMF
         List<Renderer> _proxyDomainRenderers;
         Dictionary<Renderer, Renderer> _proxy2OriginRendererDict;
 
-        Dictionary<Renderer, Action<Renderer>> _rendererApplyRecaller = new();//origin 2 apply call
+        Dictionary<Renderer, Mesh> _lastMeshes = new();
+        Dictionary<Renderer, Material[]> _lastMaterials = new();
         private IObjectRegistry _objectRegistry;
         private TTCEUnityWithTTT4UnityOnNDMFPreview _ttce4U;
 
@@ -86,12 +93,21 @@ namespace net.rs64.TexTransTool.NDMF
         }
         public IEnumerable<Renderer> EnumerateRenderers() { return _proxyDomainRenderers; }
 
-        private void RegisterRecall(Renderer proxyRenderer, Action<Renderer> recall)
+        private Renderer GetOriginalRenderer(Renderer proxyRenderer)
         {
-            if (!_proxy2OriginRendererDict.ContainsKey(proxyRenderer)) { throw new InvalidOperationException($" {proxyRenderer.name} はプロキシーリストにないよ...?"); }
+            if (!_proxy2OriginRendererDict.TryGetValue(proxyRenderer, out var originalRenderer))
+                throw new InvalidOperationException($" {proxyRenderer.name} はプロキシーリストにないよ...?");
+            return originalRenderer;
+        }
 
-            if (_rendererApplyRecaller.ContainsKey(_proxy2OriginRendererDict[proxyRenderer])) { _rendererApplyRecaller[_proxy2OriginRendererDict[proxyRenderer]] += recall; }
-            else { _rendererApplyRecaller[_proxy2OriginRendererDict[proxyRenderer]] = recall; }
+        private void SetRecallMesh(Renderer proxyRenderer, Mesh mesh)
+        {
+            _lastMeshes[GetOriginalRenderer(proxyRenderer)] = mesh;
+        }
+
+        private void SetRecallMaterials(Renderer proxyRenderer, Material[] materials)
+        {
+            _lastMaterials[GetOriginalRenderer(proxyRenderer)] = materials;
         }
         public bool IsTemporaryAsset(UnityEngine.Object obj) { return _transferredObject.Contains(obj); }
         public void GetMutable(ref Material material)
@@ -112,21 +128,21 @@ namespace net.rs64.TexTransTool.NDMF
         {
             foreach (var dr in _proxyDomainRenderers)
             {
-                RegisterRecall(dr, i => RendererUtility.SwapMaterials(i, mapping));
-                RendererUtility.SwapMaterials(dr, mapping);
+                var materials = RendererUtility.SwapMaterials(dr, mapping);
+                SetRecallMaterials(dr, materials);
             }
             UsedMaterialReplace = true;
         }
 
         public void SetMesh(Renderer renderer, Mesh mesh)
         {
-            RegisterRecall(renderer, i => i.SetMesh(mesh));
+            SetRecallMesh(renderer, mesh);
             renderer.SetMesh(mesh);
             UsedSetMesh = true;
         }
         public void SetMaterials(Renderer renderer, Material[] materials)
         {
-            RegisterRecall(renderer, i => i.sharedMaterials = materials);
+            SetRecallMaterials(renderer, materials);
             renderer.sharedMaterials = materials;
             UsedMaterialReplace = true;
         }
@@ -214,16 +230,44 @@ namespace net.rs64.TexTransTool.NDMF
 
         internal void DomainRecaller(Renderer original, Renderer proxy)
         {
-            if (_rendererApplyRecaller.Any() is false) { return; }
-            if (!_rendererApplyRecaller.ContainsKey(original))
+            using (DomainRecallerMarker.Auto())
             {
-#if TTT_DISPLAY_RUNTIME_LOG
-                Debug.Log($"{original.name} is can not Recall");
-#endif
-                return;
-            }
+                if (_lastMeshes.Count == 0 && _lastMaterials.Count == 0) { return; }
 
-            _rendererApplyRecaller[original].Invoke(proxy);
+                bool hasMesh;
+                bool hasMaterials;
+                Mesh mesh;
+                Material[] materials;
+                using (DomainRecallerLookupMarker.Auto())
+                {
+                    hasMesh = _lastMeshes.TryGetValue(original, out mesh);
+                    hasMaterials = _lastMaterials.TryGetValue(original, out materials);
+                }
+
+                if (!hasMesh && !hasMaterials)
+                {
+#if TTT_DISPLAY_RUNTIME_LOG
+                    Debug.Log($"{original.name} is can not Recall");
+#endif
+                    return;
+                }
+
+                if (hasMesh)
+                {
+                    using (DomainRecallerSetMeshMarker.Auto())
+                    {
+                        proxy.SetMesh(mesh);
+                    }
+                }
+
+                if (hasMaterials)
+                {
+                    using (DomainRecallerSetMaterialsMarker.Auto())
+                    {
+                        proxy.sharedMaterials = materials;
+                    }
+                }
+            }
         }
         public ITexTransToolForUnity GetTexTransCoreEngineForUnity() => _ttce4U;
 

--- a/Editor/NDMF/TexTransPhaseNode.cs
+++ b/Editor/NDMF/TexTransPhaseNode.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using nadena.dev.ndmf;
 using nadena.dev.ndmf.preview;
 using net.rs64.TexTransTool.Build;
+using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.Profiling;
 
@@ -11,6 +12,8 @@ namespace net.rs64.TexTransTool.NDMF
 {
     internal class TexTransPhaseNode : IRenderFilterNode
     {
+        private static readonly ProfilerMarker OnFrameMarker = new("TexTransPhaseNode.OnFrame");
+
         //TODO : 決め打ちじゃなくて、もっと調べて正しい状態にしてもいい気がする。
         public RenderAspects Reads => _nodeDomain.UsedLookAt ? RenderAspects.Everything : 0;
         public RenderAspects WhatChanged
@@ -56,7 +59,10 @@ namespace net.rs64.TexTransTool.NDMF
         }
         public void OnFrame(Renderer original, Renderer proxy)
         {
-            _nodeDomain.DomainRecaller(original, proxy);
+            using (OnFrameMarker.Auto())
+            {
+                _nodeDomain.DomainRecaller(original, proxy);
+            }
         }
 
         void IDisposable.Dispose()

--- a/Runtime/Utils/RendererUtility.cs
+++ b/Runtime/Utils/RendererUtility.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.Pool;
 
@@ -7,6 +9,11 @@ namespace net.rs64.TexTransTool.Utils
 {
     internal static class RendererUtility
     {
+        private static readonly ProfilerMarker SwapMaterialsMarker = new("RendererUtility.SwapMaterials");
+        private static readonly ProfilerMarker GetSharedMaterialsMarker = new("RendererUtility.SwapMaterials.GetSharedMaterials");
+        private static readonly ProfilerMarker MapMaterialsMarker = new("RendererUtility.SwapMaterials.MapMaterials");
+        private static readonly ProfilerMarker AssignSharedMaterialsMarker = new("RendererUtility.SwapMaterials.AssignSharedMaterials");
+
         /// <summary>
         /// マテリアルをとりあえず集めてくる。同一物を消したりなどしない。
         /// </summary>
@@ -33,11 +40,36 @@ namespace net.rs64.TexTransTool.Utils
             return output;
         }
         public static void SwapMaterials(IEnumerable<Renderer> renderers, Dictionary<Material, Material> matMap) { foreach (var r in renderers) { SwapMaterials(r, matMap); } }
-        public static void SwapMaterials(Renderer renderer, Dictionary<Material, Material> matMap)
+        public static Material[] SwapMaterials(Renderer renderer, Dictionary<Material, Material> matMap)
         {
-            if (renderer == null) { return; }
-            if (!renderer.sharedMaterials.Any()) { return; }
-            renderer.sharedMaterials = renderer.sharedMaterials.Select(i => i != null ? matMap.TryGetValue(i, out var r) ? r : i : i).ToArray();
+            if (renderer == null) { return Array.Empty<Material>(); }
+
+            using (SwapMaterialsMarker.Auto())
+            {
+                Material[] sourceMaterials;
+                using (GetSharedMaterialsMarker.Auto())
+                {
+                    sourceMaterials = renderer.sharedMaterials;
+                }
+
+                if (!sourceMaterials.Any())
+                {
+                    return sourceMaterials;
+                }
+
+                Material[] swappedMaterials;
+                using (MapMaterialsMarker.Auto())
+                {
+                    swappedMaterials = sourceMaterials
+                        .Select(i => i != null ? matMap.TryGetValue(i, out var r) ? r : i : i).ToArray();
+                }
+
+                using (AssignSharedMaterialsMarker.Auto())
+                {
+                    renderer.sharedMaterials = swappedMaterials;
+                    return swappedMaterials;
+                }
+            }
         }
         public static Mesh GetMesh(this Renderer target)
         {


### PR DESCRIPTION
以前、NodeExecuteDomainは同じRendererで複数回マテリアルを参照し、
置き換え判定を行い、適用する処理となっていた。しかし、結果として同じ
sharedMaterials に落ち着くはずなので、フレーム毎にこの処理を行う
必要はない。最終的な sharedMaterials と mesh を適用する処理に変えること
によって大幅にパフォーマンスを改善できました。